### PR TITLE
Use str to avoid TypeError with numeric values

### DIFF
--- a/excelToMarkdown.py
+++ b/excelToMarkdown.py
@@ -38,7 +38,7 @@ for sheet_name in workbook.sheetnames:
             if column.value is None:
                 continue
 
-            columns.append(column.value)
+            columns.append(str(column.value))
 
         print("|"+"|".join(columns)+"|")
         if i == 0:


### PR DESCRIPTION
Thanks for providing this useful tool!
 
I got this error running it on a spreadsheet with numeric values:

```
Traceback (most recent call last):
  File "excelToMarkdown.py", line 43, in <module>
    print("|"+"|".join(columns)+"|")
              ^^^^^^^^^^^^^^^^^
TypeError: sequence item 1: expected str instance, int found
```

This PR uses `str(column.value)` to convert all values to string before doing the join.